### PR TITLE
fix renamed Razee kapitan-delta to razeedeploy-delta

### DIFF
--- a/.bluemix/install_razee.sh
+++ b/.bluemix/install_razee.sh
@@ -68,7 +68,7 @@ fi
 echo "=========================================================="
 echo "CHECKING Razee deployment agent is installed in the cluster"
 echo "Checking Razee RemoteResource api-resource type registered:"
-REMOTE_RESOURCE_TYPE="remoteresources.kapitan.razee.io"
+REMOTE_RESOURCE_TYPE="remoteresources.deploy.razee.io"
 #  the || true is to prevent fail on error when grep doesn't find it
 FOUND_REMOTE_RESOURCE_TYPE=$(kubectl api-resources --output=name | grep "^${REMOTE_RESOURCE_TYPE}$" || true )
 if [ ! -z "${FOUND_REMOTE_RESOURCE_TYPE}" ];
@@ -77,7 +77,7 @@ then
 else
   echo "Razee RemoteResource type does not yet exist."
 
-  RAZEE_KAPITAN_URL="https://github.com/razee-io/Kapitan-delta/releases/latest/download/resource.yaml"
+  RAZEE_DEPLOY_URL="https://github.com/razee-io/razeedeploy-delta/releases/latest/download/resource.yaml"
 
   if [[ "${INSTALL_RAZEE}" != 'true' ]];
   then
@@ -85,33 +85,33 @@ else
     no_color="\x1b[0m"
     echo -e "${red}Razee deployment agent not found in the cluster${no_color}"
     echo "Install it manually with the command:"
-    echo "  kubectl apply -f '${RAZEE_KAPITAN_URL}'"
+    echo "  kubectl apply -f '${RAZEE_DEPLOY_URL}'"
     echo "or change this pipeline stage environment property INSTALL_RAZEE to true and re-run."
     echo "For details about Razee see: https://github.com/razee-io/Razee"
     exit 1
   fi
 
   echo "Attempt register Razee deployment agent in cluster"
-  echo "kubectl apply -f '${RAZEE_KAPITAN_URL}'"
-  kubectl apply -f "${RAZEE_KAPITAN_URL}"
+  echo "kubectl apply -f '${RAZEE_DEPLOY_URL}'"
+  kubectl apply -f "${RAZEE_DEPLOY_URL}"
   echo "Verify Razee resources exist"
-  FOUND_DEPLOY_KAPITAN_DELTA=""
+  FOUND_DEPLOY_DELTA=""
   FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER=""
   FOUND_POD_REMOTE_RESOURCE_CONTROLLER=""
   for ITER in {1..5}
   do
-    if [ -z "${FOUND_DEPLOY_KAPITAN_DELTA}" ];
+    if [ -z "${FOUND_DEPLOY_DELTA}" ];
     then
-      FOUND_DEPLOY_KAPITAN_DELTA=$(kubectl get deploy -n razee --output=name | grep "kapitan-delta" || true )
-      if [ ! -z "${FOUND_DEPLOY_KAPITAN_DELTA}" ];
+      FOUND_DEPLOY_DELTA=$(kubectl get deploy -n razee --output=name | grep "razeedeploy-delta" || true )
+      if [ ! -z "${FOUND_DEPLOY_DELTA}" ];
       then
-        echo "Found deploy kapitan-delta";
-        kubectl get deploy -n razee | grep "kapitan-delta"
+        echo "Found deploy razeedeploy-delta";
+        kubectl get deploy -n razee | grep "razeedeploy-delta"
       else
-        echo "Did not find deploy kapitan-delta";
+        echo "Did not find deploy razeedeploy-delta";
       fi
     fi
-    if [ ! -z "${FOUND_DEPLOY_KAPITAN_DELTA}" ] && [ -z "${FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER}" ]; 
+    if [ ! -z "${FOUND_DEPLOY_DELTA}" ] && [ -z "${FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER}" ]; 
     then
       FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER=$(kubectl get deploy -n razee --output=name | grep "remoteresource-controller" || true )
       if [ ! -z "${FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER}" ];
@@ -123,7 +123,7 @@ else
       fi
     fi
 
-    if [ ! -z "${FOUND_DEPLOY_KAPITAN_DELTA}" ] && [ ! -z "${FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER}" ] && [ -z "${FOUND_POD_REMOTE_RESOURCE_CONTROLLER}" ]; 
+    if [ ! -z "${FOUND_DEPLOY_DELTA}" ] && [ ! -z "${FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER}" ] && [ -z "${FOUND_POD_REMOTE_RESOURCE_CONTROLLER}" ]; 
     then
       FOUND_POD_REMOTE_RESOURCE_CONTROLLER=$(kubectl get pod -n razee --output=name | grep "remoteresource-controller" || true )
       if [ ! -z "${FOUND_DEPLOY_REMOTE_RESOURCE_CONTROLLER}" ];

--- a/.bluemix/register_app.sh
+++ b/.bluemix/register_app.sh
@@ -282,7 +282,7 @@ if [ ! -f ${REMOTERESOURCE_FILE} ]; then
   # would be better to have RemoteResource headers secretKeyRef, 
   # but that mechanism doesn't exist yet.
   cat > "${REMOTERESOURCE_FILE}" << EOF
-apiVersion: "kapitan.razee.io/v1alpha1"
+apiVersion: "deploy.razee.io/v1alpha1"
 kind: MustacheTemplate
 metadata:
   name: hello-mustachetemplate${RESOURCE_SUFFIX}
@@ -303,7 +303,7 @@ spec:
         name: ${CONFIG_NAME}
         key: "${COMMIT_KEY}"
   templates:
-  - apiVersion: kapitan.razee.io/v1alpha1
+  - apiVersion: deploy.razee.io/v1alpha1
     kind: RemoteResource
     metadata:
       name: hello-config-remote${RESOURCE_SUFFIX}
@@ -315,7 +315,7 @@ spec:
           url: "${CONFIG_FILE_URL}"
           headers:
             ${CONFIG_DEPLOY_AUTH_HEADER_NAME}: "${ACCESS_TOKEN_MUSTACHE}"${CONFIG_DEPLOY_EXTRA_HEADERS}
-  - apiVersion: kapitan.razee.io/v1alpha1
+  - apiVersion: deploy.razee.io/v1alpha1
     kind: RemoteResource
     metadata:
       name: hello-deploy-remote${RESOURCE_SUFFIX}


### PR DESCRIPTION
Fix the failing job "Install Razee agent", since the deployment "kapitan-delta" has been renamed to "razeedeploy-delta" in the latest release of Razee. 
Also the old installation url redirects to a new url, so updating the url in the script.